### PR TITLE
Fix logger compile error

### DIFF
--- a/fzbz.cc
+++ b/fzbz.cc
@@ -43,9 +43,9 @@ shared_ptr<Ast> parse(const string& source, ostream& out) {
 
   parser.enable_ast();
 
-  parser.log = [&](size_t ln, size_t col, const auto& msg) {
+  parser.set_logger([&](size_t ln, size_t col, const auto& msg) {
     out << ln << ":" << col << ": " << msg << endl;
-  };
+  });
 
   shared_ptr<Ast> ast;
   if (parser.parse_n(source.data(), source.size(), ast)) {


### PR DESCRIPTION
It seems the parser struct in latest peglib.h doesn't have any log field.
On my environment, make command will be error.

```
clang++ -std=c++17 -o fzbz fzbz.cc -Wall -Wextra
fzbz.cc:46:10: error: no member named 'log' in 'peg::parser'
  parser.log = [&](size_t ln, size_t col, const auto& msg) {
  ~~~~~~ ^
1 error generated.
make: *** [Makefile:5: fzbz] エラー 1
```

Please take a look.